### PR TITLE
Security upgrade - part 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -278,6 +278,14 @@
       "dev": true,
       "requires": {
         "hoek": "4.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+          "dev": true
+        }
       }
     },
     "brace-expansion": {
@@ -313,6 +321,11 @@
       "requires": {
         "caniuse-db": "^1.0.30000153"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -616,26 +629,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-      "dev": true,
-      "requires": {
-        "boom": "5.x.x"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.x.x"
-          }
-        }
-      }
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -1590,6 +1583,24 @@
         "handlebars": ">= 1",
         "lodash.merge": ">= 2",
         "lodash.toarray": ">=2"
+      },
+      "dependencies": {
+        "handlebars": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+          "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "grunt-contrib-clean": {
@@ -2279,24 +2290,6 @@
         "duplexer": "^0.1.1"
       }
     },
-    "handlebars": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2375,13 +2368,41 @@
         "cryptiles": "3.x.x",
         "hoek": "4.x.x",
         "sntp": "2.x.x"
+      },
+      "dependencies": {
+        "cryptiles": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
+          "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
+          "dev": true,
+          "requires": {
+            "boom": "7.x.x"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "7.3.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
+              "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
+              "dev": true,
+              "requires": {
+                "hoek": "6.x.x"
+              }
+            },
+            "hoek": {
+              "version": "6.1.3",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+              "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+              "dev": true
+            }
+          }
+        },
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+          "dev": true
+        }
       }
-    },
-    "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
-      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -2705,6 +2726,11 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-format/-/json-format-1.0.1.tgz",
+      "integrity": "sha1-FD9n5irxKda//tKIpGJl6iPQ3ww="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3173,6 +3199,15 @@
         "is-builtin-module": "^1.0.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-force-resolutions": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/npm-force-resolutions/-/npm-force-resolutions-0.0.3.tgz",
+      "integrity": "sha512-xbIPAGzD3nrJHDLtnRFt/O83teTA8ju5pWTf8W6OKL4D0XD9EjdRNJhzg4bSXWuucE+l1HGdTpOJR/l1Mi1Ycg==",
+      "requires": {
+        "json-format": "^1.0.1",
+        "source-map-support": "^0.5.5"
       }
     },
     "num2fraction": {
@@ -4008,6 +4043,14 @@
       "dev": true,
       "requires": {
         "hoek": "4.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+          "dev": true
+        }
       }
     },
     "source-map": {
@@ -4028,6 +4071,22 @@
         "resolve-url": "^0.2.1",
         "source-map-url": "^0.4.0",
         "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "source-map-url": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-htmlhint-plus": "^0.6.0",
     "matchdep": "*",
+    "npm-force-resolutions": "0.0.3",
     "seap_core": "github:neontribe/seap_core"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "build": "grunt generate",
     "postinstall": "npm run build",
     "test": "grunt test"
@@ -28,5 +30,10 @@
   "devDependencies": {
     "grunt-casperjs": "^2.1.0",
     "grunt-contrib-connect": "^2.1.0"
+  },
+  "resolutions": {
+    "handlebars": "^4.5.3",
+    "cryptiles": "^4.1.2",
+    "hoek": "^5.0.3"
   }
 }

--- a/src/assessment.handlebars
+++ b/src/assessment.handlebars
@@ -19,7 +19,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta id="theme-color" name="theme-color" content="#79bde9" />
-  <link href="css/style.css" rel="stylesheet" media="all" />
+  <link href="style.css" rel="stylesheet" media="all" />
   <link href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400italic,700,300" rel="stylesheet" type="text/css" media="none" onload="if(media!='all')media='all'" />
   <title>PIP Assessment Support</title>
   <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
### Part 1 -> #188 

### Overview
- running `npm install` found 9 vulnerabilities (5 moderate, 4 high)

### Run `npm audit fix`
- updated 3 packages
- fixed 4 of 9 vulnerabilities
-  5 vulnerabilities required manual review and could not be updated

### Enter resolutions
- npm does not natively support yarn resolutions 
- [`npm-force-resolutions`](https://github.com/rogeriochaves/npm-force-resolutions) adds this functionality
- installed it and added it to package.json scripts as a pre-install feature

### Run `npm install`
- **0** vulnerabilities :sun_with_face: :fireworks: :bear: :penguin: 
- if need be, remove the node_modules before

### All tests pass
![Screenshot from 2019-12-05 17-12-52](https://user-images.githubusercontent.com/29477363/70257611-843d0400-1782-11ea-8d19-426e86574b89.png)